### PR TITLE
Use configuration files instead of value definitions in class.

### DIFF
--- a/example/app/src/main/scala/App.scala
+++ b/example/app/src/main/scala/App.scala
@@ -7,8 +7,7 @@ object Application extends App {
   import datamodel.latest.schema.Version
   println("Users in the database:")
   val dblocation = System.getProperty("user.dir") + "/test.tb"
-  println(Database.forURL(
-    s"jdbc:h2:$dblocation", driver = "org.h2.Driver").withDynSession {
+  println(MyDatabase.db.withDynSession {
     Users.map(u=>u).list
   })
  */

--- a/example/app/src/main/scala/Database.scala
+++ b/example/app/src/main/scala/Database.scala
@@ -1,0 +1,10 @@
+import com.typesafe.config._
+import scala.slick.driver.H2Driver.simple._
+import Database.dynamicSession
+
+object MyDatabase {
+  private val config = ConfigFactory.load()
+  val dburl = config.getString("migrations.db.url")
+  val dbdriver = config.getString("migrations.db.driver")
+  def db = Database.forURL(dburl, driver = dbdriver)
+}

--- a/example/migrations/src/main/resources/application.conf
+++ b/example/migrations/src/main/resources/application.conf
@@ -1,0 +1,6 @@
+migrations {
+           db {
+              url = "jdbc:h2:./test.tb"
+              driver = "org.h2.Driver"
+           }
+}

--- a/migrations/slick/build.sbt
+++ b/migrations/slick/build.sbt
@@ -12,21 +12,10 @@ scalacOptions += "-feature"
 
 libraryDependencies ++= List(
   "com.typesafe.slick" %% "slick" % "2.1.0"
-    ,"com.typesafe.slick" %% "slick-codegen" % "2.1.0"
-    ,"org.scala-lang" % "scala-compiler" % "2.11.6"
-    ,"com.h2database" % "h2" % "1.3.166"
-    ,"org.xerial" % "sqlite-jdbc" % "3.6.20"
-    ,"org.slf4j" % "slf4j-nop" % "1.6.4" // <- disables logging
-/*
-// enables logging
-  ,"org.slf4j" % "slf4j-api" % "1.6.4"
-  ,"ch.qos.logback" % "logback-classic" % "0.9.28"
-*/
-/*
-// Other database drivers
-  "org.apache.derby" % "derby" % "10.6.1.0",
-  "org.hsqldb" % "hsqldb" % "2.0.0",
-  "postgresql" % "postgresql" % "8.4-701.jdbc4",
-  "mysql" % "mysql-connector-java" % "5.1.13"
-*/
+  ,"com.typesafe.slick" %% "slick-codegen" % "2.1.0"
+  ,"org.scala-lang" % "scala-compiler" % "2.11.6"
+  ,"com.typesafe" % "config" % "1.3.0"
+  ,"com.h2database" % "h2" % "1.3.166"
+  ,"org.xerial" % "sqlite-jdbc" % "3.6.20"
+  ,"org.slf4j" % "slf4j-nop" % "1.6.4" // <- disables logging
 )


### PR DESCRIPTION
Configuration files may be a more intuitive way to make configurations for users. In this way the configurations can be changed even after the program has been compiled, and does not require a re-compilation.
Having configurations in configuration files also allow the program to read settings such as db location, during compile time or even sbt loading time, which enables doing something requiring these settings in a macro or programs under sbt `project/` directory.
