### PR TITLE
Sequential compilation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,10 @@ Demo steps (simplified output shown here; run ``run help`` for command descripti
       CREATE CACHED TABLE PUBLIC."__migrations__"(
           "id" INTEGER NOT NULL
       );
+#. update the migrations
+   ::
+      > mg update
+      create link to ./migrations/src/main/scala/migrations/1.scala for /Users/lastland/workspace/slick/migrations/example/./migrations/src_migrations/main/scala/1.scala
 #. the migration yet to be applied
    ::
       > mg status
@@ -88,16 +92,15 @@ Demo steps (simplified output shown here; run ``run help`` for command descripti
       > run
       Users in the database:
       List()
-#. To simulate database evolution: uncomment code in `SampleMigrations.scala <https://github.com/cvogt/migrations/blob/a1acbfdad28b6efa0b7db1df7d1dc264a85818d4/src/main/scala/SampleMigrations.scala>`_
+#. To simulate database evolution, continue run
+   ::
+      > mg update
 #. sql and scala code of migrations yet to be applied
    ::
       > mg preview
       2 GenericMigration:
             Users.insertAll(User(1, "Chris", "Vogt"), User(2, "Stefan", "Zeiger"))
 
-      3 SqlMigration:
-            alter table "users" alter column "first" rename to "firstname"
-            alter table "users" alter column "last" rename to "lastname"
 #. the app runs fine as the version of the last generated code matches the current db version
    ::
       > run
@@ -107,26 +110,28 @@ Demo steps (simplified output shown here; run ``run help`` for command descripti
    ::
       > mg apply
       applying migration 2
-      applying migration 3
 #. the db changed
    ::
       > mg dbdump
+      CREATE USER IF NOT EXISTS "" SALT '' HASH '' ADMIN;
       CREATE CACHED TABLE PUBLIC."__migrations__"(
           "id" INTEGER NOT NULL
       );
-      INSERT INTO PUBLIC."__migrations__"("id") VALUES (1),(2),(3);
+      ALTER TABLE PUBLIC."__migrations__" ADD CONSTRAINT PUBLIC.CONSTRAINT_A PRIMARY KEY("id");
+      -- 2 +/- SELECT COUNT(*) FROM PUBLIC."__migrations__";
+      INSERT INTO PUBLIC."__migrations__"("id") VALUES
+      (1),
+      (2);
       CREATE CACHED TABLE PUBLIC."users"(
           "id" INTEGER NOT NULL,
           "first" VARCHAR NOT NULL,
           "last" VARCHAR NOT NULL
       );
-      INSERT INTO PUBLIC."users"("id", "firstname", "lastname") VALUES
-         (1, 'Chris', 'Vogt'),
-         (2, 'Stefan', 'Zeiger');
-#. the app realizes it uses an out-dated data model
-   ::
-      > run
-      Generated code is outdated, please run code generator
+      ALTER TABLE PUBLIC."users" ADD CONSTRAINT PUBLIC.CONSTRAINT_6 PRIMARY KEY("id");
+      -- 2 +/- SELECT COUNT(*) FROM PUBLIC."users";
+      INSERT INTO PUBLIC."users"("id", "first", "last") VALUES
+      (1, 'Chris', 'Vogt'),
+      (2, 'Stefan', 'Zeiger');
 #. re-generate data model classes
    ::
       > mg codegen
@@ -134,7 +139,14 @@ Demo steps (simplified output shown here; run ``run help`` for command descripti
    ::
       > run
       Users in the database:
-      List(User(1,Chris,Vogt), User(2,Stefan,Zeiger))
+      List(UsersRow(1,Chris,Vogt), UsersRow(2,Stefan,Zeiger))
+
+Yet there's another way...
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+#. alternatively, you can simply run the following command after database has been initialized
+   ::
+      > ~mg migrate
 
 Play around yourself
 ^^^^^^^^^^^^^^^^^^^^

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -12,6 +12,7 @@ scalacOptions += "-feature"
 
 libraryDependencies ++= List(
   "org.scala-lang" % "scala-compiler" % "2.11.6"
+  ,"com.typesafe" % "config" % "1.3.0"
   ,"com.h2database" % "h2" % "1.3.166"
   ,"org.xerial" % "sqlite-jdbc" % "3.6.20"
   ,"org.slf4j" % "slf4j-nop" % "1.6.4" // <- disables logging

--- a/core/src/main/scala/Commands.scala
+++ b/core/src/main/scala/Commands.scala
@@ -1,10 +1,15 @@
 package scala.migrations
 
+import java.io.File
+import java.nio.file.Files
+
 trait RescueCommands {
   def rescueCommand: Unit
 }
 
 trait MigrationCommands[T] { this: MigrationManager[T] =>
+  def appliedMigrationIds = alreadyAppliedIds
+
   def statusCommand: Unit
   def previewCommand: Unit
   def applyCommand: Unit
@@ -22,6 +27,48 @@ trait RescueCommandLineTool { this: RescueCommands =>
 // TODO: This trait may need to be rewritten in the future.
 // e.g.: use macros etc. to make adding command (and help info) easier
 trait MigrationCommandLineTool[T] { this: MigrationCommands[T] =>
+  private lazy val config = MigrationsConfig.config
+  protected lazy val unhandledLoc =
+    config.getString("migrations.unhandled_location")
+  protected lazy val handledLoc =
+    config.getString("migrations.handled_location")
+
+  def idShouldBeHandled(id: String, appliedIds: Seq[T]): Boolean
+  def handleMigrations {
+    val unhandled = new File(unhandledLoc)
+    assert(unhandled.isDirectory)
+    val toMove: Seq[File] = for {
+      file <- unhandled.listFiles
+      fullName = file.getName
+      if fullName.endsWith(".scala")
+      name = fullName.substring(0, fullName.length - 6)
+      if name forall Character.isDigit
+      if idShouldBeHandled(name, appliedMigrationIds)
+    } yield file
+
+    for (file <- toMove) {
+      val link = new File(handledLoc + "/" + file.getName)
+      val target = new File(
+        unhandledLoc + "/" + file.getName).getAbsoluteFile.toPath
+      if (!link.exists) {
+        println("create link to " + link.toPath + " for " + target)
+        Files.createSymbolicLink(link.toPath, target)
+      }
+    }
+
+    val ids = toMove.map(n => n.getName.substring(0, n.getName.length - 6))
+    val code = "object MigrationSummary {\n" + ids.map(
+      n => "M" + n).mkString("\n") + "\n}\n"
+    val sumFile = new File(handledLoc + "/Summary.scala")
+
+    if (!sumFile.exists) sumFile.createNewFile()
+    import java.io.BufferedWriter
+    import java.io.FileWriter
+    val fw = new FileWriter(sumFile.getAbsoluteFile())
+    val bw = new BufferedWriter(fw)
+    bw.write(code)
+    bw.close()
+  }
 
   def execCommands(args: List[String]) = args match {
     case "status" :: Nil => statusCommand
@@ -29,6 +76,7 @@ trait MigrationCommandLineTool[T] { this: MigrationCommands[T] =>
     case "apply" :: Nil => applyCommand
     case "init" :: Nil => initCommand
     case "reset" :: Nil => resetCommand
+    case "update" :: Nil => handleMigrations
     case _ => println(helpOutput)
   }
 

--- a/core/src/main/scala/Migrations.scala
+++ b/core/src/main/scala/Migrations.scala
@@ -6,7 +6,7 @@ trait Migration[T]{
 }
 
 trait MigrationManager[T]{
-  def migrations : Seq[Migration[T]]
+  var migrations : Seq[Migration[T]] = List()
   def ids = migrations.map(_.id)
   def alreadyAppliedIds : Seq[T]
   def notYetAppliedMigrations = migrations.drop(alreadyAppliedIds.size)

--- a/core/src/main/scala/MigrationsConfig.scala
+++ b/core/src/main/scala/MigrationsConfig.scala
@@ -1,0 +1,7 @@
+package scala.migrations
+
+import com.typesafe.config._
+
+object MigrationsConfig {
+  val config = ConfigFactory.load()
+}

--- a/example/app/src/main/resources/application.conf
+++ b/example/app/src/main/resources/application.conf
@@ -1,0 +1,4 @@
+db {
+   url = "jdbc:h2:./test.tb"
+   driver = "org.h2.Driver"
+}

--- a/example/app/src/main/scala/App.scala
+++ b/example/app/src/main/scala/App.scala
@@ -6,7 +6,6 @@ object Application extends App {
   import datamodel.latest.schema.tables._
   import datamodel.latest.schema.Version
   println("Users in the database:")
-  val dblocation = System.getProperty("user.dir") + "/test.tb"
   println(MyDatabase.db.withDynSession {
     Users.map(u=>u).list
   })

--- a/example/app/src/main/scala/Database.scala
+++ b/example/app/src/main/scala/Database.scala
@@ -4,7 +4,7 @@ import Database.dynamicSession
 
 object MyDatabase {
   private val config = ConfigFactory.load()
-  val dburl = config.getString("migrations.db.url")
-  val dbdriver = config.getString("migrations.db.driver")
+  val dburl = config.getString("db.url")
+  val dbdriver = config.getString("db.driver")
   def db = Database.forURL(dburl, driver = dbdriver)
 }

--- a/example/migration_manager/src/main/resources/application.conf
+++ b/example/migration_manager/src/main/resources/application.conf
@@ -1,0 +1,1 @@
+include file("./migrations/src/main/resources/application.conf")

--- a/example/migration_manager/src/main/scala/Tool.scala
+++ b/example/migration_manager/src/main/scala/Tool.scala
@@ -1,10 +1,10 @@
 package example.migration.manager
 
-import scala.migrations.RescueCommandLineTool
 import scala.migrations.slick.SlickRescueCommands
+import scala.migrations.slick.SlickRescueCommandLineTool
 
 object Tool extends App
-    with RescueCommandLineTool
+    with SlickRescueCommandLineTool
     with SlickRescueCommands
     with MyCodegen {
   execCommands(args.toList)

--- a/example/migrations/src/main/resources/application.conf
+++ b/example/migrations/src/main/resources/application.conf
@@ -1,4 +1,6 @@
 migrations {
+           unhandled_location = "./migrations/src_migrations/main/scala"
+           handled_location = "./migrations/src/main/scala/migrations"
            db {
               url = "jdbc:h2:./test.tb"
               driver = "org.h2.Driver"

--- a/example/migrations/src/main/resources/application.conf
+++ b/example/migrations/src/main/resources/application.conf
@@ -1,8 +1,5 @@
 migrations {
            unhandled_location = "./migrations/src_migrations/main/scala"
            handled_location = "./migrations/src/main/scala/migrations"
-           db {
-              url = "jdbc:h2:./test.tb"
-              driver = "org.h2.Driver"
-           }
+           include file("./app/src/main/resources/application.conf")
 }

--- a/example/migrations/src/main/scala/Migrations.scala
+++ b/example/migrations/src/main/scala/Migrations.scala
@@ -1,38 +1,10 @@
 import scala.migrations.slick._
-import example.migration.manager.MyMigrationManager
-//import scala.migrations.plain._
 
-trait Migrations extends MyMigrationManager {
-  import scala.slick.driver.H2Driver.simple._
-  // WARNING!! never change version number or contents of any already published migration
-  override def migrations  = List(
-/*
-    PlainMigration( 1 ){
-      println("Hello World 1!")
-    },
-    PlainMigration( 2 ){
-      println("Hello World 2!")
-    }
- */
-    SqlMigration( 1 )(List(
-       """create table "users" ("id" INTEGER NOT NULL PRIMARY KEY,"first" VARCHAR NOT NULL,"last" VARCHAR NOT NULL)"""
-    ))
-/*
-    ,GenericMigration( 2 )({
-      // this is typesafe :), but requires the corresponding code version to have been generated
-      import datamodel.v1.schema.tables.Users
-      import datamodel.v1.schema.tables.UsersRow
-      // if you really have to do content changes in migrations, make sure they cannot conflict with data in one of your installations
-      implicit session =>  Users.insertAll(
-        UsersRow(1,"Chris","Vogt"),
-        UsersRow(2,"Stefan","Zeiger")
-      )
-    })
-    ,SqlMigration( 3 )(List(
-      // SQL for changing the table again, as we do not have a type-safe, db independent API for that in Slick yet
-       """alter table "users" alter column "first" rename to "firstname" """,
-       """alter table "users" alter column "last" rename to "lastname" """
-    ))
- */
-  )
+object MyMigrations extends App
+    with SlickMigrationCommandLineTool
+    with SlickMigrationCommands
+    with SlickMigrationManager
+    with Codegen {
+  MigrationSummary
+  execCommands(args.toList)
 }

--- a/example/migrations/src/main/scala/Tool.scala
+++ b/example/migrations/src/main/scala/Tool.scala
@@ -1,9 +1,0 @@
-import scala.migrations.slick._
-
-object Tool extends App
-    with SlickMigrationCommandLineTool
-    with SlickMigrationCommands
-    with Migrations
-    with Codegen {
-  execCommands(args.toList)
-}

--- a/example/migrations/src/main/scala/migrations/Summary.scala
+++ b/example/migrations/src/main/scala/migrations/Summary.scala
@@ -1,0 +1,2 @@
+object MigrationSummary {
+}

--- a/example/migrations/src_migrations/main/scala/1.scala
+++ b/example/migrations/src_migrations/main/scala/1.scala
@@ -1,0 +1,7 @@
+import scala.migrations.slick.SqlMigration
+
+object M1 {
+  MyMigrations.migrations = MyMigrations.migrations :+ SqlMigration(1)(List(
+    """create table "users" ("id" INTEGER NOT NULL PRIMARY KEY,"first" VARCHAR NOT NULL,"last" VARCHAR NOT NULL)"""
+))
+}

--- a/example/migrations/src_migrations/main/scala/2.scala
+++ b/example/migrations/src_migrations/main/scala/2.scala
@@ -1,0 +1,15 @@
+import scala.slick.driver.H2Driver.simple._
+import scala.migrations.slick.GenericMigration
+
+object M2 {
+  MyMigrations.migrations = MyMigrations.migrations :+ GenericMigration( 2 )({
+    // this is typesafe :), but requires the corresponding code version to have been generated
+    import datamodel.v1.schema.tables.Users
+    import datamodel.v1.schema.tables.UsersRow
+    // if you really have to do content changes in migrations, make sure they cannot conflict with data in one of your installations
+    implicit session =>  Users.insertAll(
+      UsersRow(1,"Chris","Vogt"),
+      UsersRow(2,"Stefan","Zeiger")
+    )
+  })
+}

--- a/example/migrations/src_migrations/main/scala/3.scala
+++ b/example/migrations/src_migrations/main/scala/3.scala
@@ -1,0 +1,9 @@
+import scala.migrations.slick.SqlMigration
+
+object M3 {
+  MyMigrations.migrations = MyMigrations.migrations :+ SqlMigration( 3 )(List(
+    // SQL for changing the table again, as we do not have a type-safe, db independent API for that in Slick yet
+    """alter table "users" alter column "first" rename to "firstname" """,
+    """alter table "users" alter column "last" rename to "lastname" """
+  ))
+}

--- a/migrations/slick/src/main/scala/Commands.scala
+++ b/migrations/slick/src/main/scala/Commands.scala
@@ -82,6 +82,10 @@ trait SlickMigrationCommands extends MigrationCommands[Int] {
 trait SlickMigrationCommandLineTool extends MigrationCommandLineTool[Int] {
   this: SlickMigrationCommands =>
 
+  override def idShouldBeHandled(id: String, appliedIds: Seq[Int]) =
+    if (appliedIds.isEmpty) id.toInt == 1
+    else id.toInt <= appliedIds.max + 1
+
   override def execCommands(args: List[String]) = args match {
     case "dbdump" :: Nil => dbdumpCommand
     case "codegen" :: Nil => codegenCommand

--- a/migrations/slick/src/main/scala/SlickMigrationManager.scala
+++ b/migrations/slick/src/main/scala/SlickMigrationManager.scala
@@ -16,6 +16,7 @@ class MigrationsTable(tag: Tag) extends Table[Int](tag, "__migrations__") {
 
 trait SlickMigrationManager extends MigrationManager[Int] {
   private lazy val config = MigrationsConfig.config
+
   protected lazy val dburl = config.getString("migrations.db.url")
   protected lazy val dbdriver = config.getString("migrations.db.driver")
 


### PR DESCRIPTION
The easiest way to do the migration would be running `~mg migrate` in sbt under `example` directory.

Alternatively, users can use `mg update` to add the next migration file to `src` directory, and then use commands like `preview`, `apply`, `codegen` to simulate the database evolution manually.
